### PR TITLE
Fix: Use correct median instead of minimum (#1)

### DIFF
--- a/ssh_ping.go
+++ b/ssh_ping.go
@@ -51,7 +51,7 @@ func min(s []time.Duration) time.Duration {
 }
 
 func median(s []time.Duration) time.Duration {
-	return computeDurationStat(stats.Min, s)
+	return computeDurationStat(stats.Median, s)
 }
 
 func percentile(percent float64, s []time.Duration) time.Duration {


### PR DESCRIPTION
Modified the median function to correctly utilize `stats.Median` instead of `stats.Min` for calculating the median of time durations.